### PR TITLE
make hover run more flexible.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,12 @@
 				"js-tokens": "^4.0.0"
 			}
 		},
+		"@types/js-yaml": {
+			"version": "3.12.3",
+			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.3.tgz",
+			"integrity": "sha512-otRe77JNNWzoVGLKw8TCspKswRoQToys4tuL6XYVBFxjgeM0RUrx7m3jkaTdxILxeGry3zM8mGYkGXMeQ02guA==",
+			"dev": true
+		},
 		"@types/node": {
 			"version": "12.12.36",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.36.tgz",
@@ -55,7 +61,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -135,8 +140,7 @@
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -190,7 +194,6 @@
 			"version": "3.13.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
 			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -259,8 +262,7 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"supports-color": {
 			"version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -47,9 +47,11 @@
 		"dart-code.flutter"
 	],
 	"dependencies": {
+		"js-yaml": "^3.13.1",
 		"tree-kill": "^1.2.2"
 	},
 	"devDependencies": {
+		"@types/js-yaml": "^3.12.3",
 		"@types/node": "^12.12.0",
 		"@types/vscode": "^1.34.0",
 		"tslint": "^5.19.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,85 @@
 import * as vscode from 'vscode';
 import { isUndefined } from 'util';
 import { runHoverRun } from './util';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as jsyaml from 'js-yaml';
+
+// detectPubspecFromDir recursively scans up from a directory for the pubspec.yaml
+// this lets us detect the flutter root directory. returns empty string if not found.
+function detectPubspecFromDir(dir: string): string {
+	console.debug("detectPubspecFromDir", dir)
+
+	let previous = undefined
+	for (let current = dir; current != previous; current = path.dirname(current)) {
+		try {
+			fs.statSync(path.join(current, "pubspec.yaml"))
+			return current
+		} catch (error) {
+			if (error.code !== "ENOENT") {
+				throw error
+			}
+		}
+
+		previous = current
+	}
+
+	return ""
+}
+
+// detectRootFromHoverConfig if current editor is the hover.yaml use that to determine the base path.
+// special case, no need to scan workspace if current editor is hover.yaml
+function detectRootFromHoverConfig(currentPath: vscode.Uri): string {
+	if (currentPath.fsPath.endsWith("hover.yaml")) {
+		console.debug("detected hover yaml", currentPath.fsPath)
+		return detectPubspecFromDir(path.dirname(currentPath.fsPath))
+	}
+
+	return ""
+}
+
+// detectRootFromWorkspace detects the root flutter directory from the workspace.
+function detectRootFromWorkspaces(currentPath: vscode.Uri, workspaces: vscode.WorkspaceFolder[]): string {
+	console.debug("detecting flutter root from workspaces", currentPath, workspaces)
+	let workspace = workspaces.find((element) => {
+		return currentPath.toString().startsWith(element.uri.toString())
+	})
+
+	if (isUndefined(workspace)) {
+		return "";
+	}
+
+	return workspace.uri.fsPath
+}
+
+function detectWorkspaceFor(dir: string, workspaces: vscode.WorkspaceFolder[]): vscode.WorkspaceFolder | undefined {
+	console.debug("detectWorkspaceFor", dir, workspaces)
+	let workspace = workspaces.find((element) => {
+		return dir.startsWith(element.uri.fsPath)
+	})
+
+	return workspace
+}
+
+function configOrDefault(p: string, fallback: any): any {
+	try {
+		return {...fallback, ...jsyaml.load(fs.readFileSync(p, "utf8"))}
+	} catch (error) {
+		vscode.window.showWarningMessage(`failed to read hover.yaml falling back to defaults: ${path}`)
+		return fallback
+	}
+}
+
+function logException(msg: string, cb: () => void): () => void {
+	return () => {
+		try {
+			cb()
+		} catch (error) {
+			console.error(msg, error)
+			throw error
+		}
+	}
+}
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
 	console.log('The Hover extension is being activated.');
@@ -44,7 +123,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	// the actual debugger), we can also obtain the target through the 'program'
 	// value in launch.json
 
-	let disposable = vscode.commands.registerCommand('hover.run', () => {
+	let disposable = vscode.commands.registerCommand('hover.run', logException("hover.run failed", () => {
 		let workspaceFolders = vscode.workspace.workspaceFolders;
 		if (isUndefined(workspaceFolders)) {
 			vscode.window.showErrorMessage('No active workspace available to launch Hover for.');
@@ -57,25 +136,29 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 			return;
 		}
 		const activeDocumentUri = activeEditor.document.uri;
-		let activeWorkspaceFolder: vscode.WorkspaceFolder | undefined;
-		workspaceFolders.forEach(element => {
-			console.log(element.uri.toString());
-			console.log(activeDocumentUri.toString());
-			if (activeDocumentUri.toString().startsWith(element.uri.toString())) {
-				activeWorkspaceFolder = element;
-			}
-		});
-		if (isUndefined(activeWorkspaceFolder)) {
+
+
+		let cwd = detectRootFromHoverConfig(activeDocumentUri) ||
+			detectPubspecFromDir(path.dirname(activeDocumentUri.fsPath)) ||
+			detectRootFromWorkspaces(activeDocumentUri, workspaceFolders)
+
+		if (cwd == "") {
 			vscode.window.showErrorMessage('No active workspace found to launch Hover for.');
 			return;
 		}
 
-		let cwd = activeWorkspaceFolder.uri.fsPath;
-		let target = "lib/main_desktop.dart"; // TODO: make configurable, probably best done through launch configurations with a param...
+		let workspace = detectWorkspaceFor(cwd, workspaceFolders)
+
+		if (isUndefined(workspace)) {
+			vscode.window.showErrorMessage('No active workspace found to launch Hover for.');
+			return;
+		}
+
+		const config = configOrDefault(path.join(cwd, "go", "hover.yaml"), {target: "lib/main_desktop.dart"})
 
 		runHoverRun(
 			[
-				"--target", target,
+				"--target", config.target,
 				"--colors=false", // TODO: Fix colors in output stream, if possible.
 			],
 			cwd,
@@ -83,20 +166,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 			console.log("runHover started, have observatoryUri");
 			vscode.window.showInformationMessage('Starting application in debug mode');
 			console.log("Attaching debugger (flutter attach)");
-			vscode.debug.startDebugging(activeWorkspaceFolder, {
+			vscode.debug.startDebugging(workspace, {
 				name: "Flutter attached to Hover",
 				type: "dart",
 				request: "attach",
 				deviceId: "flutter-tester",
 				observatoryUri: observatoryUri,
-				program: target,
+				program: config.target,
 			});
 		}).catch((err: any) => {
 			console.log("runHover exception");
 			console.dir(err);
 		});
-
-	});
+	}));
 
 	context.subscriptions.push(disposable);
 	console.log('The Hover extension is now active.');


### PR DESCRIPTION
- if activated when editor has hover.yaml open, use that to determine
  the flutter root directory.
- if activated scan parent directories of the current file for pubspec.yaml to determine
  flutter root directory.
- if activated and all other strategies fail fallback to current
  strategy of detecting which workspace the current file belongs to
  and use that as flutter root.